### PR TITLE
Fix rebase and merge strategy in GitHub Actions

### DIFF
--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -36,4 +36,6 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git commit --all -m "Update gemset.nix via bundix" || echo "No changes to commit"
-          git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" --force-with-lease ${{ github.event.pull_request.head.ref }}:refs/heads/${{ github.event.pull_request.head.ref }}
+          git fetch origin
+          git rebase origin/${{ github.event.pull_request.head.ref }} || git merge origin/${{ github.event.pull_request.head.ref }}
+          git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" ${{ github.event.pull_request.head.ref }}:refs/heads/${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
- Updated the workflow to fetch the latest changes from the origin.
- Implemented a rebase strategy with a fallback to merge if rebase fails.
- Removed the force-with-lease option from the push command to ensure a safer update process.