### PR TITLE
Add push trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
       - synchronize
+  push:
+    branches:
+      - '**'
 
 jobs:
   tests:


### PR DESCRIPTION
- Updated the GitHub Actions CI workflow to trigger on all branch pushes.
- This change ensures that the CI pipeline runs for every push event across all branches.