### PR TITLE
Update json gem to version 2.10.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.10.1)
+    json (2.10.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)

--- a/gemset.nix
+++ b/gemset.nix
@@ -436,12 +436,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1p4l5ycdxfsr8b51gnvlvhq6s21vmx9z4x617003zbqv3bcqmj6x";
+      sha256 = "01lbdaizhkxmrw4y8j3wpvsryvnvzmg0pfs56c52laq2jgdfmq1l";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "2.10.1";
+    version = "2.10.2";
   };
   kramdown = {
     dependencies = ["rexml"];


### PR DESCRIPTION
- Updated Gemfile.lock to use json version 2.10.2
- Updated gemset.nix with the new sha256 and version for json 2.10.2