### PR TITLE
Fix visual regression: CJK fonts and embed wait

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -103,7 +103,7 @@ jobs:
             name="$(basename "$diff_img" .png)"
             prod="test/visual/screenshots/production/$(basename "$diff_img")"
             local="test/visual/screenshots/local/$(basename "$diff_img")"
-            echo "<div class='page'><h2>${name}</h2><div class='imgs'>" >> test/visual/diff-report.html
+            echo "<div class='page' id='${name}'><h2>${name}</h2><div class='imgs'>" >> test/visual/diff-report.html
             for pair in "Production:$prod" "Local:$local" "Diff:$diff_img"; do
               label="${pair%%:*}"; img="${pair#*:}"
               if [ -f "$img" ]; then
@@ -125,7 +125,7 @@ jobs:
           path: test/visual/diff-report.html
           archive: false
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: visual-diff
@@ -133,13 +133,12 @@ jobs:
 
       - name: Comment on PR
         if: always()
+        env:
+          DIFF_URL: ${{ steps.diff-html.outputs.artifact-url }}
         run: |
           if [ -f test/visual/report.md ]; then
-            {
-              cat test/visual/report.md
-              echo ""
-              echo "[View diff images](${{ steps.diff-html.outputs.artifact-url }})"
-            } > test/visual/report-full.md
+            sed -E "s%\| ([a-z_]+)\.png \|%| [\1.png](${DIFF_URL}#\1) |%g" \
+              test/visual/report.md > test/visual/report-full.md
           else
             echo "## Visual Regression Report" > test/visual/report-full.md
             echo "" >> test/visual/report-full.md

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -81,83 +81,51 @@ jobs:
         if: always()
         run: nix run .#visual-optimize -- test/visual/screenshots/diff
 
-      - name: Build diff viewer HTML
+      - name: Build diff viewer pages
         if: always()
         run: |
-          cat > test/visual/diff-report.html <<'HEADER'
+          mkdir -p test/visual/diff-pages/img
+          # Copy thumbnails (or originals as fallback) into img/
+          for src_dir in production local diff; do
+            for img in test/visual/screenshots/${src_dir}/*.png; do
+              [ -f "$img" ] || continue
+              base="$(basename "$img" .png)"
+              thumb="test/visual/screenshots/${src_dir}/thumbs/$(basename "$img")"
+              [ -f "$thumb" ] || thumb="$img"
+              cp "$thumb" "test/visual/diff-pages/img/${base}_${src_dir}.png"
+            done
+          done
+          # Generate per-page HTML with relative image paths
+          for diff_img in test/visual/screenshots/diff/*.png; do
+            [ -f "$diff_img" ] || continue
+            name="$(basename "$diff_img" .png)"
+            cat > "test/visual/diff-pages/${name}.html" <<EOF
           <!DOCTYPE html>
-          <html><head><meta charset="utf-8"><title>Visual Regression Diff</title>
+          <html><head><meta charset="utf-8"><title>${name} - Visual Diff</title>
           <style>
           body{font-family:system-ui;max-width:1400px;margin:0 auto;padding:20px;background:#f6f8fa}
           h1{border-bottom:2px solid #d0d7de;padding-bottom:8px}
-          nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px}
-          nav a{padding:6px 12px;border:1px solid #d0d7de;border-radius:6px;text-decoration:none;color:#0969da;background:#fff}
-          nav a.active{background:#0969da;color:#fff}
-          .page{display:none;background:#fff;border:1px solid #d0d7de;border-radius:6px;padding:16px}
-          .page.active{display:block}
-          .page h2{margin-top:0}
           .imgs{display:flex;gap:8px;overflow-x:auto}
           .imgs figure{margin:0;flex:1;min-width:0}
           .imgs figcaption{font-weight:600;text-align:center;padding:4px 0}
           .imgs img{width:100%;border:1px solid #d0d7de;display:block}
           </style></head><body>
-          <h1>Visual Regression Diff</h1><nav id="tabs"></nav>
-          HEADER
-
-          names=""
-          for diff_img in test/visual/screenshots/diff/*.png; do
-            [ -f "$diff_img" ] || continue
-            name="$(basename "$diff_img" .png)"
-            names="$names $name"
-            prod="test/visual/screenshots/production/$(basename "$diff_img")"
-            local="test/visual/screenshots/local/$(basename "$diff_img")"
-            echo "<div class='page' id='${name}'><h2>${name}</h2><div class='imgs'>" >> test/visual/diff-report.html
-            for pair in "Production:$prod" "Local:$local" "Diff:$diff_img"; do
-              label="${pair%%:*}"; img="${pair#*:}"
-              if [ -f "$img" ]; then
-                thumb="${img%/*}/thumbs/$(basename "$img")"
-                [ -f "$thumb" ] || thumb="$img"
-                b64="$(base64 -w0 "$thumb")"
-                echo "<figure><figcaption>${label}</figcaption><img data-src='data:image/png;base64,${b64}'></figure>" >> test/visual/diff-report.html
-              fi
-            done
-            echo "</div></div>" >> test/visual/diff-report.html
+          <h1>${name}</h1>
+          <div class='imgs'>
+          <figure><figcaption>Production</figcaption><img src='img/${name}_production.png'></figure>
+          <figure><figcaption>Local</figcaption><img src='img/${name}_local.png'></figure>
+          <figure><figcaption>Diff</figcaption><img src='img/${name}_diff.png'></figure>
+          </div></body></html>
+          EOF
           done
-
-          cat >> test/visual/diff-report.html <<'FOOTER'
-          <script>
-          function show(id){
-            document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
-            document.querySelectorAll('nav a').forEach(a=>a.classList.remove('active'));
-            const el=document.getElementById(id);
-            if(el){
-              el.classList.add('active');
-              el.querySelectorAll('img[data-src]').forEach(img=>{
-                img.src=img.dataset.src;img.removeAttribute('data-src');
-              });
-            }
-            const tab=document.querySelector('nav a[href="#'+id+'"]');
-            if(tab){tab.classList.add('active');}
-          }
-          document.querySelectorAll('.page').forEach(p=>{
-            const a=document.createElement('a');
-            a.href='#'+p.id; a.textContent=p.id;
-            a.onclick=e=>{e.preventDefault();history.replaceState(null,'','#'+p.id);show(p.id);};
-            document.getElementById('tabs').appendChild(a);
-          });
-          const h=location.hash.slice(1);
-          show(h||document.querySelector('.page')?.id||'');
-          window.addEventListener('hashchange',()=>show(location.hash.slice(1)));
-          </script></body></html>
-          FOOTER
 
       - name: Upload diff viewer
         if: always()
         id: diff-html
         uses: actions/upload-artifact@v7
         with:
-          path: test/visual/diff-report.html
-          archive: false
+          name: visual-diff-viewer
+          path: test/visual/diff-pages/
 
       - uses: actions/upload-artifact@v7
         if: always()
@@ -171,8 +139,11 @@ jobs:
           DIFF_URL: ${{ steps.diff-html.outputs.artifact-url }}
         run: |
           if [ -f test/visual/report.md ]; then
-            sed -E "s%\| ([a-z_]+)\.png \|%| [\1.png](${DIFF_URL}#\1) |%g" \
-              test/visual/report.md > test/visual/report-full.md
+            {
+              cat test/visual/report.md
+              echo ""
+              echo "[Download diff viewer](${DIFF_URL})"
+            } > test/visual/report-full.md
           else
             echo "## Visual Regression Report" > test/visual/report-full.md
             echo "" >> test/visual/report-full.md

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -81,46 +81,77 @@ jobs:
         if: always()
         run: nix run .#visual-optimize -- test/visual/screenshots/diff
 
-      - name: Build diff viewer pages
+      - name: Build diff viewer HTML
         if: always()
         run: |
-          mkdir -p test/visual/diff-pages
-          for diff_img in test/visual/screenshots/diff/*.png; do
-            [ -f "$diff_img" ] || continue
-            name="$(basename "$diff_img" .png)"
-            prod="test/visual/screenshots/production/$(basename "$diff_img")"
-            local="test/visual/screenshots/local/$(basename "$diff_img")"
-            out="test/visual/diff-pages/${name}.html"
-            cat > "$out" <<HEADER
+          cat > test/visual/diff-report.html <<'HEADER'
           <!DOCTYPE html>
-          <html><head><meta charset="utf-8"><title>${name} - Visual Diff</title>
+          <html><head><meta charset="utf-8"><title>Visual Regression Diff</title>
           <style>
           body{font-family:system-ui;max-width:1400px;margin:0 auto;padding:20px;background:#f6f8fa}
           h1{border-bottom:2px solid #d0d7de;padding-bottom:8px}
+          nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px}
+          nav a{padding:6px 12px;border:1px solid #d0d7de;border-radius:6px;text-decoration:none;color:#0969da;background:#fff}
+          nav a.active{background:#0969da;color:#fff}
+          .page{display:none;background:#fff;border:1px solid #d0d7de;border-radius:6px;padding:16px}
+          .page.active{display:block}
+          .page h2{margin-top:0}
           .imgs{display:flex;gap:8px;overflow-x:auto}
           .imgs figure{margin:0;flex:1;min-width:0}
           .imgs figcaption{font-weight:600;text-align:center;padding:4px 0}
           .imgs img{width:100%;border:1px solid #d0d7de;display:block}
-          </style></head><body><h1>${name}</h1><div class='imgs'>
+          </style></head><body>
+          <h1>Visual Regression Diff</h1><nav id="tabs"></nav>
           HEADER
+
+          names=""
+          for diff_img in test/visual/screenshots/diff/*.png; do
+            [ -f "$diff_img" ] || continue
+            name="$(basename "$diff_img" .png)"
+            names="$names $name"
+            prod="test/visual/screenshots/production/$(basename "$diff_img")"
+            local="test/visual/screenshots/local/$(basename "$diff_img")"
+            echo "<div class='page' id='${name}'><h2>${name}</h2><div class='imgs'>" >> test/visual/diff-report.html
             for pair in "Production:$prod" "Local:$local" "Diff:$diff_img"; do
               label="${pair%%:*}"; img="${pair#*:}"
               if [ -f "$img" ]; then
                 thumb="${img%/*}/thumbs/$(basename "$img")"
                 [ -f "$thumb" ] || thumb="$img"
                 b64="$(base64 -w0 "$thumb")"
-                echo "<figure><figcaption>${label}</figcaption><img src='data:image/png;base64,${b64}'></figure>" >> "$out"
+                echo "<figure><figcaption>${label}</figcaption><img src='data:image/png;base64,${b64}'></figure>" >> test/visual/diff-report.html
               fi
             done
-            echo "</div></body></html>" >> "$out"
+            echo "</div></div>" >> test/visual/diff-report.html
           done
+
+          cat >> test/visual/diff-report.html <<'FOOTER'
+          <script>
+          function show(id){
+            document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
+            document.querySelectorAll('nav a').forEach(a=>a.classList.remove('active'));
+            const el=document.getElementById(id);
+            if(el){el.classList.add('active');}
+            const tab=document.querySelector('nav a[href="#'+id+'"]');
+            if(tab){tab.classList.add('active');}
+          }
+          document.querySelectorAll('.page').forEach(p=>{
+            const a=document.createElement('a');
+            a.href='#'+p.id; a.textContent=p.id;
+            a.onclick=e=>{e.preventDefault();history.replaceState(null,'','#'+p.id);show(p.id);};
+            document.getElementById('tabs').appendChild(a);
+          });
+          const h=location.hash.slice(1);
+          show(h||document.querySelector('.page')?.id||'');
+          window.addEventListener('hashchange',()=>show(location.hash.slice(1)));
+          </script></body></html>
+          FOOTER
 
       - name: Upload diff viewer
         if: always()
         id: diff-html
         uses: actions/upload-artifact@v7
         with:
-          path: test/visual/diff-pages/
+          path: test/visual/diff-report.html
           archive: false
 
       - uses: actions/upload-artifact@v7
@@ -135,7 +166,7 @@ jobs:
           DIFF_URL: ${{ steps.diff-html.outputs.artifact-url }}
         run: |
           if [ -f test/visual/report.md ]; then
-            sed -E "s%\| ([a-z_]+)\.png \|%| [\1.png](${DIFF_URL}/\1.html) |%g" \
+            sed -E "s%\| ([a-z_]+)\.png \|%| [\1.png](${DIFF_URL}#\1) |%g" \
               test/visual/report.md > test/visual/report-full.md
           else
             echo "## Visual Regression Report" > test/visual/report-full.md

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -99,7 +99,7 @@ jobs:
           .imgs{display:flex;gap:8px;overflow-x:auto}
           .imgs figure{margin:0;flex:1;min-width:0}
           .imgs figcaption{font-weight:600;text-align:center;padding:4px 0}
-          .imgs img{width:100%;border:1px solid #d0d7de;display:block}
+          .imgs img{max-width:100%;border:1px solid #d0d7de;display:block}
           </style></head><body>
           <h1>Visual Regression Diff</h1><nav id="tabs"></nav>
           HEADER

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -77,6 +77,10 @@ jobs:
               test/visual/screenshots/diff
           } > test/visual/report.md
 
+      - name: Optimize diff images
+        if: always()
+        run: nix run .#visual-optimize -- test/visual/screenshots/diff
+
       - name: Build diff viewer HTML
         if: always()
         run: |
@@ -103,7 +107,9 @@ jobs:
             for pair in "Production:$prod" "Local:$local" "Diff:$diff_img"; do
               label="${pair%%:*}"; img="${pair#*:}"
               if [ -f "$img" ]; then
-                b64="$(magick "$img" -resize 480x png:- | base64 -w0)"
+                thumb="${img%/*}/thumbs/$(basename "$img")"
+                [ -f "$thumb" ] || thumb="$img"
+                b64="$(base64 -w0 "$thumb")"
                 echo "<figure><figcaption>${label}</figcaption><img src='data:image/png;base64,${b64}'></figure>" >> test/visual/diff-report.html
               fi
             done

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -125,12 +125,12 @@ jobs:
           function show(id){
             document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
             document.querySelectorAll('nav a').forEach(a=>a.classList.remove('active'));
-            const el=document.getElementById(id);
+            const el=document.getElementById(id)||document.querySelector('.page');
             if(el){
               el.classList.add('active');
               el.querySelectorAll('img[data-src]').forEach(i=>{i.src=i.dataset.src;i.removeAttribute('data-src');});
             }
-            const tab=document.querySelector('nav a[href="#'+id+'"]');
+            const tab=document.querySelector('nav a[href="#'+(el?.id||id)+'"]');
             if(tab){tab.classList.add('active');}
           }
           document.querySelectorAll('.page').forEach(p=>{

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -81,48 +81,46 @@ jobs:
         if: always()
         run: nix run .#visual-optimize -- test/visual/screenshots/diff
 
-      - name: Build diff viewer HTML
+      - name: Build diff viewer pages
         if: always()
         run: |
-          cat > test/visual/diff-report.html <<'HEADER'
-          <!DOCTYPE html>
-          <html><head><meta charset="utf-8"><title>Visual Regression Diff</title>
-          <style>
-          body{font-family:system-ui;max-width:1400px;margin:0 auto;padding:20px;background:#f6f8fa}
-          h1{border-bottom:2px solid #d0d7de;padding-bottom:8px}
-          .page{margin:24px 0;background:#fff;border:1px solid #d0d7de;border-radius:6px;padding:16px}
-          .page h2{margin-top:0}
-          .imgs{display:flex;gap:8px;overflow-x:auto}
-          .imgs figure{margin:0;flex:1;min-width:0}
-          .imgs figcaption{font-weight:600;text-align:center;padding:4px 0}
-          .imgs img{width:100%;border:1px solid #d0d7de;display:block}
-          </style></head><body><h1>Visual Regression Diff</h1>
-          HEADER
+          mkdir -p test/visual/diff-pages
           for diff_img in test/visual/screenshots/diff/*.png; do
             [ -f "$diff_img" ] || continue
             name="$(basename "$diff_img" .png)"
             prod="test/visual/screenshots/production/$(basename "$diff_img")"
             local="test/visual/screenshots/local/$(basename "$diff_img")"
-            echo "<div class='page' id='${name}'><h2>${name}</h2><div class='imgs'>" >> test/visual/diff-report.html
+            out="test/visual/diff-pages/${name}.html"
+            cat > "$out" <<HEADER
+          <!DOCTYPE html>
+          <html><head><meta charset="utf-8"><title>${name} - Visual Diff</title>
+          <style>
+          body{font-family:system-ui;max-width:1400px;margin:0 auto;padding:20px;background:#f6f8fa}
+          h1{border-bottom:2px solid #d0d7de;padding-bottom:8px}
+          .imgs{display:flex;gap:8px;overflow-x:auto}
+          .imgs figure{margin:0;flex:1;min-width:0}
+          .imgs figcaption{font-weight:600;text-align:center;padding:4px 0}
+          .imgs img{width:100%;border:1px solid #d0d7de;display:block}
+          </style></head><body><h1>${name}</h1><div class='imgs'>
+          HEADER
             for pair in "Production:$prod" "Local:$local" "Diff:$diff_img"; do
               label="${pair%%:*}"; img="${pair#*:}"
               if [ -f "$img" ]; then
                 thumb="${img%/*}/thumbs/$(basename "$img")"
                 [ -f "$thumb" ] || thumb="$img"
                 b64="$(base64 -w0 "$thumb")"
-                echo "<figure><figcaption>${label}</figcaption><img src='data:image/png;base64,${b64}'></figure>" >> test/visual/diff-report.html
+                echo "<figure><figcaption>${label}</figcaption><img src='data:image/png;base64,${b64}'></figure>" >> "$out"
               fi
             done
-            echo "</div></div>" >> test/visual/diff-report.html
+            echo "</div></body></html>" >> "$out"
           done
-          echo "</body></html>" >> test/visual/diff-report.html
 
       - name: Upload diff viewer
         if: always()
         id: diff-html
         uses: actions/upload-artifact@v7
         with:
-          path: test/visual/diff-report.html
+          path: test/visual/diff-pages/
           archive: false
 
       - uses: actions/upload-artifact@v7
@@ -137,7 +135,7 @@ jobs:
           DIFF_URL: ${{ steps.diff-html.outputs.artifact-url }}
         run: |
           if [ -f test/visual/report.md ]; then
-            sed -E "s%\| ([a-z_]+)\.png \|%| [\1.png](${DIFF_URL}#\1) |%g" \
+            sed -E "s%\| ([a-z_]+)\.png \|%| [\1.png](${DIFF_URL}/\1.html) |%g" \
               test/visual/report.md > test/visual/report-full.md
           else
             echo "## Visual Regression Report" > test/visual/report-full.md

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -55,10 +55,14 @@ jobs:
           timeout 30 bash -c 'until curl -sf http://localhost:4000 > /dev/null; do sleep 1; done'
 
       - name: Screenshot local
-        run: nix run .#visual-screenshots -- http://localhost:4000 test/visual/screenshots/local
+        run: |
+          nix run .#visual-screenshots -- http://localhost:4000 test/visual/screenshots/local
+          nix run .#visual-optimize -- test/visual/screenshots/local
 
       - name: Screenshot production
-        run: nix run .#visual-screenshots -- https://nymphium.github.io test/visual/screenshots/production
+        run: |
+          nix run .#visual-screenshots -- https://nymphium.github.io test/visual/screenshots/production
+          nix run .#visual-optimize -- test/visual/screenshots/production
 
       - name: Compare screenshots
         id: compare
@@ -99,7 +103,7 @@ jobs:
             for pair in "Production:$prod" "Local:$local" "Diff:$diff_img"; do
               label="${pair%%:*}"; img="${pair#*:}"
               if [ -f "$img" ]; then
-                b64="$(base64 -w0 "$img")"
+                b64="$(magick "$img" -resize 480x png:- | base64 -w0)"
                 echo "<figure><figcaption>${label}</figcaption><img src='data:image/png;base64,${b64}'></figure>" >> test/visual/diff-report.html
               fi
             done

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -152,12 +152,6 @@ jobs:
           path: test/visual/diff-report.html
           archive: false
 
-      - uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: visual-diff
-          path: test/visual/screenshots/
-
       - name: Comment on PR
         if: always()
         env:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -118,7 +118,7 @@ jobs:
                 thumb="${img%/*}/thumbs/$(basename "$img")"
                 [ -f "$thumb" ] || thumb="$img"
                 b64="$(base64 -w0 "$thumb")"
-                echo "<figure><figcaption>${label}</figcaption><img src='data:image/png;base64,${b64}'></figure>" >> test/visual/diff-report.html
+                echo "<figure><figcaption>${label}</figcaption><img data-src='data:image/png;base64,${b64}'></figure>" >> test/visual/diff-report.html
               fi
             done
             echo "</div></div>" >> test/visual/diff-report.html
@@ -130,7 +130,12 @@ jobs:
             document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
             document.querySelectorAll('nav a').forEach(a=>a.classList.remove('active'));
             const el=document.getElementById(id);
-            if(el){el.classList.add('active');}
+            if(el){
+              el.classList.add('active');
+              el.querySelectorAll('img[data-src]').forEach(img=>{
+                img.src=img.dataset.src;img.removeAttribute('data-src');
+              });
+            }
             const tab=document.querySelector('nav a[href="#'+id+'"]');
             if(tab){tab.classList.add('active');}
           }

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -81,51 +81,76 @@ jobs:
         if: always()
         run: nix run .#visual-optimize -- test/visual/screenshots/diff
 
-      - name: Build diff viewer pages
+      - name: Build diff viewer HTML
         if: always()
         run: |
-          mkdir -p test/visual/diff-pages/img
-          # Copy thumbnails (or originals as fallback) into img/
-          for src_dir in production local diff; do
-            for img in test/visual/screenshots/${src_dir}/*.png; do
-              [ -f "$img" ] || continue
-              base="$(basename "$img" .png)"
-              thumb="test/visual/screenshots/${src_dir}/thumbs/$(basename "$img")"
-              [ -f "$thumb" ] || thumb="$img"
-              cp "$thumb" "test/visual/diff-pages/img/${base}_${src_dir}.png"
-            done
-          done
-          # Generate per-page HTML with relative image paths
-          for diff_img in test/visual/screenshots/diff/*.png; do
-            [ -f "$diff_img" ] || continue
-            name="$(basename "$diff_img" .png)"
-            cat > "test/visual/diff-pages/${name}.html" <<EOF
+          cat > test/visual/diff-report.html <<'HEADER'
           <!DOCTYPE html>
-          <html><head><meta charset="utf-8"><title>${name} - Visual Diff</title>
+          <html><head><meta charset="utf-8"><title>Visual Regression Diff</title>
           <style>
           body{font-family:system-ui;max-width:1400px;margin:0 auto;padding:20px;background:#f6f8fa}
           h1{border-bottom:2px solid #d0d7de;padding-bottom:8px}
+          nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px}
+          nav a{padding:6px 12px;border:1px solid #d0d7de;border-radius:6px;text-decoration:none;color:#0969da;background:#fff;cursor:pointer}
+          nav a.active{background:#0969da;color:#fff}
+          .page{display:none}
+          .page.active{display:block}
+          .page h2{margin-top:0}
           .imgs{display:flex;gap:8px;overflow-x:auto}
           .imgs figure{margin:0;flex:1;min-width:0}
           .imgs figcaption{font-weight:600;text-align:center;padding:4px 0}
           .imgs img{width:100%;border:1px solid #d0d7de;display:block}
           </style></head><body>
-          <h1>${name}</h1>
-          <div class='imgs'>
-          <figure><figcaption>Production</figcaption><img src='img/${name}_production.png'></figure>
-          <figure><figcaption>Local</figcaption><img src='img/${name}_local.png'></figure>
-          <figure><figcaption>Diff</figcaption><img src='img/${name}_diff.png'></figure>
-          </div></body></html>
-          EOF
+          <h1>Visual Regression Diff</h1><nav id="tabs"></nav>
+          HEADER
+          for diff_img in test/visual/screenshots/diff/*.png; do
+            [ -f "$diff_img" ] || continue
+            name="$(basename "$diff_img" .png)"
+            prod="test/visual/screenshots/production/$(basename "$diff_img")"
+            local="test/visual/screenshots/local/$(basename "$diff_img")"
+            echo "<div class='page' id='${name}'><h2>${name}</h2><div class='imgs'>" >> test/visual/diff-report.html
+            for pair in "Production:$prod" "Local:$local" "Diff:$diff_img"; do
+              label="${pair%%:*}"; img="${pair#*:}"
+              if [ -f "$img" ]; then
+                thumb="${img%/*}/thumbs/$(basename "$img")"
+                [ -f "$thumb" ] || thumb="$img"
+                b64="$(base64 -w0 "$thumb")"
+                echo "<figure><figcaption>${label}</figcaption><img data-src='data:image/png;base64,${b64}'></figure>" >> test/visual/diff-report.html
+              fi
+            done
+            echo "</div></div>" >> test/visual/diff-report.html
           done
+          cat >> test/visual/diff-report.html <<'FOOTER'
+          <script>
+          function show(id){
+            document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
+            document.querySelectorAll('nav a').forEach(a=>a.classList.remove('active'));
+            const el=document.getElementById(id);
+            if(el){
+              el.classList.add('active');
+              el.querySelectorAll('img[data-src]').forEach(i=>{i.src=i.dataset.src;i.removeAttribute('data-src');});
+            }
+            const tab=document.querySelector('nav a[href="#'+id+'"]');
+            if(tab){tab.classList.add('active');}
+          }
+          document.querySelectorAll('.page').forEach(p=>{
+            const a=document.createElement('a');
+            a.href='#'+p.id;a.textContent=p.id;
+            a.onclick=e=>{e.preventDefault();history.replaceState(null,'','#'+p.id);show(p.id);};
+            document.getElementById('tabs').appendChild(a);
+          });
+          show(location.hash.slice(1)||document.querySelector('.page')?.id||'');
+          window.addEventListener('hashchange',()=>show(location.hash.slice(1)));
+          </script></body></html>
+          FOOTER
 
       - name: Upload diff viewer
         if: always()
         id: diff-html
         uses: actions/upload-artifact@v7
         with:
-          name: visual-diff-viewer
-          path: test/visual/diff-pages/
+          path: test/visual/diff-report.html
+          archive: false
 
       - uses: actions/upload-artifact@v7
         if: always()
@@ -139,11 +164,8 @@ jobs:
           DIFF_URL: ${{ steps.diff-html.outputs.artifact-url }}
         run: |
           if [ -f test/visual/report.md ]; then
-            {
-              cat test/visual/report.md
-              echo ""
-              echo "[Download diff viewer](${DIFF_URL})"
-            } > test/visual/report-full.md
+            sed -E "s%\| ([a-z_]+)\.png \|%| [\1.png](${DIFF_URL}#\1) |%g" \
+              test/visual/report.md > test/visual/report-full.md
           else
             echo "## Visual Regression Report" > test/visual/report-full.md
             echo "" >> test/visual/report-full.md

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,10 @@
             type = "app";
             program = "${visual-test}/bin/visual-screenshots";
           };
+          visual-optimize = {
+            type = "app";
+            program = "${visual-test}/bin/visual-optimize";
+          };
           visual-compare = {
             type = "app";
             program = "${visual-test}/bin/visual-compare";

--- a/nix/visual-test.nix
+++ b/nix/visual-test.nix
@@ -48,7 +48,12 @@ stdenv.mkDerivation {
 
     makeWrapper ${node}/bin/node $out/bin/visual-optimize \
       --add-flags $out/lib/visual-test/optimize.mjs \
-      --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.optipng ]}
+      --prefix PATH : ${
+        pkgs.lib.makeBinPath [
+          pkgs.optipng
+          pkgs.imagemagick
+        ]
+      }
 
     makeWrapper $out/lib/visual-test/compare.sh $out/bin/visual-compare \
       --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.imagemagick ]}

--- a/nix/visual-test.nix
+++ b/nix/visual-test.nix
@@ -25,12 +25,14 @@ stdenv.mkDerivation {
 
   buildInputs = [
     pkgs.imagemagick
+    pkgs.optipng
   ];
 
   installPhase = ''
     mkdir -p $out/bin $out/lib/visual-test $out/lib/node_modules
 
     cp $src/screenshots.mjs $out/lib/visual-test/
+    cp $src/optimize.mjs $out/lib/visual-test/
     cp $src/compare.sh $out/lib/visual-test/
     chmod +x $out/lib/visual-test/compare.sh
 
@@ -43,6 +45,10 @@ stdenv.mkDerivation {
       --set FONTCONFIG_FILE ${fontconfig-conf} \
       --prefix NODE_PATH : $out/lib/node_modules \
       --add-flags $out/lib/visual-test/screenshots.mjs
+
+    makeWrapper ${node}/bin/node $out/bin/visual-optimize \
+      --add-flags $out/lib/visual-test/optimize.mjs \
+      --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.optipng ]}
 
     makeWrapper $out/lib/visual-test/compare.sh $out/bin/visual-compare \
       --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.imagemagick ]}

--- a/nix/visual-test.nix
+++ b/nix/visual-test.nix
@@ -5,6 +5,13 @@
 let
   playwright-browsers = pkgs.playwright-driver.browsers;
   node = pkgs.nodejs;
+
+  fonts = pkgs.symlinkJoin {
+    name = "visual-test-fonts";
+    paths = [ pkgs.noto-fonts-cjk-sans ];
+  };
+
+  fontconfig-conf = pkgs.makeFontsConf { fontDirectories = [ fonts ]; };
 in
 stdenv.mkDerivation {
   name = "visual-test";
@@ -33,6 +40,7 @@ stdenv.mkDerivation {
     makeWrapper ${node}/bin/node $out/bin/visual-screenshots \
       --set PLAYWRIGHT_BROWSERS_PATH ${playwright-browsers} \
       --set PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS true \
+      --set FONTCONFIG_FILE ${fontconfig-conf} \
       --prefix NODE_PATH : $out/lib/node_modules \
       --add-flags $out/lib/visual-test/screenshots.mjs
 

--- a/test/visual/optimize.mjs
+++ b/test/visual/optimize.mjs
@@ -16,7 +16,7 @@ const pngs = readdirSync(dir).filter((f) => f.endsWith(".png"));
 for (const png of pngs) {
   const path = join(dir, png);
   console.log(`optipng: ${path}`);
-  execFileSync("optipng", ["-o4", "-quiet", "-strip", "all", path]);
+  execFileSync("optipng", ["-o1", "-quiet", "-strip", "all", path]);
 }
 
 // Generate thumbnails for the diff viewer HTML

--- a/test/visual/optimize.mjs
+++ b/test/visual/optimize.mjs
@@ -29,7 +29,7 @@ for (const png of pngs) {
   execFileSync("magick", [
     path,
     "-resize",
-    "360x",
+    "200x",
     "-strip",
     "-define",
     "png:compression-level=9",

--- a/test/visual/optimize.mjs
+++ b/test/visual/optimize.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdirSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
@@ -10,23 +10,31 @@ if (!dir) {
   process.exit(1);
 }
 
-const pngs = readdirSync(dir).filter((f) => f.endsWith(".png"));
+if (!existsSync(dir)) {
+  console.warn(`Directory not found: ${dir}, skipping`);
+  process.exit(0);
+}
 
-// Lossless compression
+const pngs = readdirSync(dir).filter((f) => f.endsWith(".png"));
+const thumbDir = join(dir, "thumbs");
+mkdirSync(thumbDir, { recursive: true });
+
 for (const png of pngs) {
   const path = join(dir, png);
   console.log(`optipng: ${path}`);
   execFileSync("optipng", ["-o1", "-quiet", "-strip", "all", path]);
-}
 
-// Generate thumbnails for the diff viewer HTML
-const thumbDir = join(dir, "thumbs");
-mkdirSync(thumbDir, { recursive: true });
-for (const png of pngs) {
-  const src = join(dir, png);
   const dst = join(thumbDir, png);
   console.log(`thumbnail: ${dst}`);
-  execFileSync("magick", [src, "-resize", "360x", "-quality", "95", dst]);
+  execFileSync("magick", [
+    path,
+    "-resize",
+    "360x",
+    "-strip",
+    "-define",
+    "png:compression-level=9",
+    dst,
+  ]);
 }
 
 console.log(`Optimized ${pngs.length} images`);

--- a/test/visual/optimize.mjs
+++ b/test/visual/optimize.mjs
@@ -16,7 +16,7 @@ const pngs = readdirSync(dir).filter((f) => f.endsWith(".png"));
 for (const png of pngs) {
   const path = join(dir, png);
   console.log(`optipng: ${path}`);
-  execFileSync("optipng", ["-o2", "-quiet", path]);
+  execFileSync("optipng", ["-o4", "-quiet", "-strip", "all", path]);
 }
 
 // Generate thumbnails for the diff viewer HTML
@@ -26,7 +26,7 @@ for (const png of pngs) {
   const src = join(dir, png);
   const dst = join(thumbDir, png);
   console.log(`thumbnail: ${dst}`);
-  execFileSync("magick", [src, "-resize", "480x", dst]);
+  execFileSync("magick", [src, "-resize", "360x", "-quality", "95", dst]);
 }
 
 console.log(`Optimized ${pngs.length} images`);

--- a/test/visual/optimize.mjs
+++ b/test/visual/optimize.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+const dir = process.argv[2];
+if (!dir) {
+  console.error("Usage: node optimize.mjs <screenshot-dir>");
+  process.exit(1);
+}
+
+const pngs = readdirSync(dir).filter((f) => f.endsWith(".png"));
+for (const png of pngs) {
+  const path = join(dir, png);
+  console.log(`optipng: ${path}`);
+  execFileSync("optipng", ["-o2", "-quiet", path]);
+}
+console.log(`Optimized ${pngs.length} images`);

--- a/test/visual/optimize.mjs
+++ b/test/visual/optimize.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readdirSync } from "node:fs";
+import { mkdirSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
@@ -11,9 +11,22 @@ if (!dir) {
 }
 
 const pngs = readdirSync(dir).filter((f) => f.endsWith(".png"));
+
+// Lossless compression
 for (const png of pngs) {
   const path = join(dir, png);
   console.log(`optipng: ${path}`);
   execFileSync("optipng", ["-o2", "-quiet", path]);
 }
+
+// Generate thumbnails for the diff viewer HTML
+const thumbDir = join(dir, "thumbs");
+mkdirSync(thumbDir, { recursive: true });
+for (const png of pngs) {
+  const src = join(dir, png);
+  const dst = join(thumbDir, png);
+  console.log(`thumbnail: ${dst}`);
+  execFileSync("magick", [src, "-resize", "480x", dst]);
+}
+
 console.log(`Optimized ${pngs.length} images`);

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -27,17 +27,23 @@ async function main() {
 
   mkdirSync(outDir, { recursive: true });
 
-  const browser = await firefox.launch({ headless: true });
+  const browser = await firefox.launch({
+    headless: true,
+    firefoxUserPrefs: {
+      // Disable :visited link styling so local vs production URLs
+      // don't produce diffs from different visited-link state
+      "layout.css.visited_links_enabled": false,
+    },
+  });
 
   try {
     for (const viewport of VIEWPORTS) {
-      for (const pg of PAGES) {
-        // Fresh context per page so no :visited history accumulates
-        const context = await browser.newContext({
-          viewport: { width: viewport.width, height: viewport.height },
-        });
-        const page = await context.newPage();
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
 
+      for (const pg of PAGES) {
         const url = new URL(pg.path, origin).href;
         console.log(`[${viewport.label}] ${pg.label}: ${url}`);
 
@@ -70,9 +76,9 @@ async function main() {
           fullPage: true,
         });
         console.log(`  -> ${outDir}/${filename}`);
-
-        await context.close();
       }
+
+      await context.close();
     }
   } finally {
     await browser.close();

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -41,14 +41,6 @@ async function main() {
       const context = await browser.newContext({
         viewport: { width: viewport.width, height: viewport.height },
       });
-      // Inject animation-disabling CSS before any page loads so the initial
-      // computed styles are deterministic (not frozen at a random mid-frame)
-      await context.addInitScript(() => {
-        const style = document.createElement("style");
-        style.textContent =
-          "*, *::before, *::after { animation: none !important; transition: none !important; }";
-        (document.head || document.documentElement).appendChild(style);
-      });
       const page = await context.newPage();
 
       for (const pg of PAGES) {
@@ -59,6 +51,16 @@ async function main() {
         // (Twitter/Hatena/utteranc.es) can keep background requests going
         // and prevent network from ever becoming idle
         await page.goto(url, { waitUntil: "load", timeout: 30000 });
+
+        // Cancel all running animations and prevent new ones via CSS.
+        // This must happen after goto so the DOM is fully available.
+        await page.evaluate(() => {
+          document.getAnimations().forEach((a) => a.cancel());
+        });
+        await page.addStyleTag({
+          content:
+            "*, *::before, *::after { animation: none !important; transition: none !important; }",
+        });
 
         if (pg.label === "blog") {
           // GithubRepoWidget.init is deferred with setTimeout(..., 3000),

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -70,9 +70,12 @@ async function main() {
             .waitForSelector('.github-widget[github-widget-rendered="1"]', {
               timeout: 10000,
             })
-            .catch(() => {
-              console.warn("  GitHub widget did not render; falling back to delay");
-              return page.waitForTimeout(5000);
+            .catch((err) => {
+              if (err.name === "TimeoutError" || err.message?.includes("Timeout")) {
+                console.warn("  GitHub widget timed out; falling back to delay");
+                return page.waitForTimeout(5000);
+              }
+              throw err;
             });
         } else if (pg.label === "slide") {
           // Wait for pdf.js to create and paint the canvas

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -46,11 +46,22 @@ async function main() {
         await page.addStyleTag({
           content: "*, *::before, *::after { animation: none !important; transition: none !important; }",
         });
-        await page.waitForTimeout(3000);
 
-        if (pg.label === "slide") {
+        if (pg.label === "blog") {
+          // GithubRepoWidget.init is deferred with setTimeout(..., 3000),
+          // so wait for the widget to signal it has rendered
+          await page
+            .waitForSelector(
+              '.github-widget[github-widget-rendered="1"], .github-box',
+              { timeout: 10000 },
+            )
+            .catch(() => {
+              console.warn(
+                "  GitHub widget did not render in time; continuing",
+              );
+            });
+        } else if (pg.label === "slide") {
           await page.waitForSelector("canvas", { timeout: 30000 });
-          await page.waitForTimeout(2000);
         }
 
         const filename = `${pg.label}_${viewport.label}.png`;

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -55,22 +55,19 @@ async function main() {
         const url = new URL(pg.path, origin).href;
         console.log(`[${viewport.label}] ${pg.label}: ${url}`);
 
-        await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
+        // Use "load" instead of "networkidle" — third-party scripts
+        // (Twitter/Hatena/utteranc.es) can keep background requests going
+        // and prevent network from ever becoming idle
+        await page.goto(url, { waitUntil: "load", timeout: 30000 });
 
         if (pg.label === "blog") {
           // GithubRepoWidget.init is deferred with setTimeout(..., 3000),
           // wait for it to actually finish rendering (not just .github-box
           // which appears before the API response fills in content)
-          await page
-            .waitForSelector(
-              '.github-widget[github-widget-rendered="1"]',
-              { timeout: 10000 },
-            )
-            .catch(() => {
-              console.warn(
-                "  GitHub widget did not render in time; continuing",
-              );
-            });
+          await page.waitForSelector(
+            '.github-widget[github-widget-rendered="1"]',
+            { timeout: 10000 },
+          );
         } else if (pg.label === "slide") {
           await page.waitForSelector("canvas", { timeout: 30000 });
         }

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -31,19 +31,20 @@ async function main() {
 
   try {
     for (const viewport of VIEWPORTS) {
-      const context = await browser.newContext({
-        viewport: { width: viewport.width, height: viewport.height },
-      });
-      const page = await context.newPage();
-
       for (const pg of PAGES) {
+        // Fresh context per page so no :visited history accumulates
+        const context = await browser.newContext({
+          viewport: { width: viewport.width, height: viewport.height },
+        });
+        const page = await context.newPage();
+
         const url = new URL(pg.path, origin).href;
         console.log(`[${viewport.label}] ${pg.label}: ${url}`);
 
         await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
-        // Neutralize :visited styling so navigation order doesn't cause diffs
+        // Freeze CSS animations so timing-dependent styles (e.g. .rainbow hue-rotate) are deterministic
         await page.addStyleTag({
-          content: "a:visited { color: inherit !important; }",
+          content: "*, *::before, *::after { animation: none !important; transition: none !important; }",
         });
         await page.waitForTimeout(3000);
 
@@ -58,9 +59,9 @@ async function main() {
           fullPage: true,
         });
         console.log(`  -> ${outDir}/${filename}`);
-      }
 
-      await context.close();
+        await context.close();
+      }
     }
   } finally {
     await browser.close();

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -41,6 +41,14 @@ async function main() {
       const context = await browser.newContext({
         viewport: { width: viewport.width, height: viewport.height },
       });
+      // Inject animation-disabling CSS before any page loads so the initial
+      // computed styles are deterministic (not frozen at a random mid-frame)
+      await context.addInitScript(() => {
+        const style = document.createElement("style");
+        style.textContent =
+          "*, *::before, *::after { animation: none !important; transition: none !important; }";
+        (document.head || document.documentElement).appendChild(style);
+      });
       const page = await context.newPage();
 
       for (const pg of PAGES) {
@@ -48,17 +56,14 @@ async function main() {
         console.log(`[${viewport.label}] ${pg.label}: ${url}`);
 
         await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
-        // Freeze CSS animations so timing-dependent styles (e.g. .rainbow hue-rotate) are deterministic
-        await page.addStyleTag({
-          content: "*, *::before, *::after { animation: none !important; transition: none !important; }",
-        });
 
         if (pg.label === "blog") {
           // GithubRepoWidget.init is deferred with setTimeout(..., 3000),
-          // so wait for the widget to signal it has rendered
+          // wait for it to actually finish rendering (not just .github-box
+          // which appears before the API response fills in content)
           await page
             .waitForSelector(
-              '.github-widget[github-widget-rendered="1"], .github-box',
+              '.github-widget[github-widget-rendered="1"]',
               { timeout: 10000 },
             )
             .catch(() => {

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -41,6 +41,10 @@ async function main() {
         console.log(`[${viewport.label}] ${pg.label}: ${url}`);
 
         await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
+        // Neutralize :visited styling so navigation order doesn't cause diffs
+        await page.addStyleTag({
+          content: "a:visited { color: inherit !important; }",
+        });
         await page.waitForTimeout(3000);
 
         if (pg.label === "slide") {

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -40,8 +40,8 @@ async function main() {
         const url = new URL(pg.path, origin).href;
         console.log(`[${viewport.label}] ${pg.label}: ${url}`);
 
-        await page.goto(url, { waitUntil: "load", timeout: 10000 });
-        await page.waitForTimeout(2000);
+        await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
+        await page.waitForTimeout(3000);
 
         if (pg.label === "slide") {
           await page.waitForSelector("canvas", { timeout: 30000 });

--- a/test/visual/screenshots.mjs
+++ b/test/visual/screenshots.mjs
@@ -64,14 +64,28 @@ async function main() {
 
         if (pg.label === "blog") {
           // GithubRepoWidget.init is deferred with setTimeout(..., 3000),
-          // wait for it to actually finish rendering (not just .github-box
-          // which appears before the API response fills in content)
-          await page.waitForSelector(
-            '.github-widget[github-widget-rendered="1"]',
-            { timeout: 10000 },
-          );
+          // wait for it to actually finish rendering. Fall back to a delay
+          // if the GitHub API is rate-limited/unreachable.
+          await page
+            .waitForSelector('.github-widget[github-widget-rendered="1"]', {
+              timeout: 10000,
+            })
+            .catch(() => {
+              console.warn("  GitHub widget did not render; falling back to delay");
+              return page.waitForTimeout(5000);
+            });
         } else if (pg.label === "slide") {
+          // Wait for pdf.js to create and paint the canvas
           await page.waitForSelector("canvas", { timeout: 30000 });
+          await page.waitForFunction(
+            () => {
+              const c = document.querySelector("canvas");
+              if (!c) return false;
+              const r = c.getBoundingClientRect();
+              return c.width > 0 && c.height > 0 && r.width > 0 && r.height > 0;
+            },
+            { timeout: 30000 },
+          );
         }
 
         const filename = `${pg.label}_${viewport.label}.png`;


### PR DESCRIPTION
## Summary
- Add `noto-fonts-cjk-sans` with fontconfig to the Nix derivation so Firefox renders Japanese text correctly instead of tofu glyphs
- Disable `:visited` link styling via Firefox pref (`layout.css.visited_links_enabled=false`) to prevent diffs from differing visited-link state between local and production URLs
- Cancel CSS animations via Web Animations API and inject `animation: none` CSS to make timing-dependent styles (e.g. `.rainbow` hue-rotate) deterministic
- Use `waitUntil: "load"` with explicit `waitForSelector` for async content (GitHub widget, pdf.js canvas) instead of `networkidle` which can hang on third-party scripts
- Compress screenshots with optipng and generate thumbnails for the diff viewer HTML

## Test plan
- [ ] Verify `nix eval` passes for all visual-test apps
- [ ] Run visual regression test and confirm Japanese text renders correctly
- [ ] Confirm no diffs from visited links or animation timing
- [ ] Confirm GitHub repo embeds appear in blog screenshots
- [ ] Verify diff viewer HTML uses compressed thumbnails

🤖 Generated with [Claude Code](https://claude.com/claude-code)