### PR TITLE
Use BOT_PAT in dependabot hook to trigger CI

### DIFF
--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.head_ref }}
-          token: ${{ secrets.BOT_PAT }}
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
@@ -37,3 +36,4 @@ jobs:
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
           message: "Update gemset.nix via bundix"
+          github_token: ${{ secrets.BOT_PAT || github.token }}

--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.head_ref }}
+          token: ${{ secrets.BOT_PAT }}
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |


### PR DESCRIPTION
## Summary
- `hook-dependabot-rb` の checkout で `BOT_PAT` を使用するように変更
- `GITHUB_TOKEN` によるpushは `synchronize` イベントを発火しないため、bundixによる `gemset.nix` 更新後にCIが再実行されない問題を修正
- ref: #139

## Test plan
- [ ] dependabot PRが来た際に、bundixコミット後にCIが自動で再実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)