### PR TITLE
Add auto-merge workflow with path-based strategy

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,35 @@
+name: Auto merge on approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  auto-merge:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Determine merge strategy and merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          FILES=$(gh pr diff "$PR_NUMBER" --name-only --repo "$GITHUB_REPOSITORY")
+          CONTENT_ONLY=true
+          while IFS= read -r f; do
+            case "$f" in
+              _posts/*|src/*|pdf/*|pictures/*|about/*) ;;
+              *) CONTENT_ONLY=false; break ;;
+            esac
+          done <<< "$FILES"
+
+          if [ "$CONTENT_ONLY" = true ]; then
+            echo "Content-only PR: using rebase merge"
+            gh pr merge "$PR_NUMBER" --rebase --repo "$GITHUB_REPOSITORY"
+          else
+            echo "Non-content PR: using merge commit"
+            gh pr merge "$PR_NUMBER" --merge --repo "$GITHUB_REPOSITORY"
+          fi

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,6 +18,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           FILES=$(gh pr diff "$PR_NUMBER" --name-only --repo "$GITHUB_REPOSITORY")
+          if [ -z "$FILES" ]; then
+            echo "No changed files found; skipping"
+            exit 0
+          fi
+
           CONTENT_ONLY=true
           while IFS= read -r f; do
             case "$f" in
@@ -28,8 +33,8 @@ jobs:
 
           if [ "$CONTENT_ONLY" = true ]; then
             echo "Content-only PR: using rebase merge"
-            gh pr merge "$PR_NUMBER" --rebase --repo "$GITHUB_REPOSITORY"
+            gh pr merge "$PR_NUMBER" --auto --rebase --repo "$GITHUB_REPOSITORY"
           else
             echo "Non-content PR: using merge commit"
-            gh pr merge "$PR_NUMBER" --merge --repo "$GITHUB_REPOSITORY"
+            gh pr merge "$PR_NUMBER" --auto --merge --repo "$GITHUB_REPOSITORY"
           fi


### PR DESCRIPTION
## Summary
- approve をトリガーに自動マージするワークフローを追加
- `_posts/`, `src/`, `pdf/`, `pictures/`, `about/` のみの変更 → rebase merge
- それ以外を含む変更 → merge commit
- リポジトリ設定で merge commit を有効化済み

## Test plan
- [ ] コンテンツのみの PR を approve して rebase merge されることを確認
- [ ] ワークフロー変更等を含む PR を approve して merge commit されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)