### PR TITLE
Add language icons and grid-based line numbers to code blocks

### DIFF
--- a/_plugins/ordered/html_filters/99-listing_name_into_div.rb
+++ b/_plugins/ordered/html_filters/99-listing_name_into_div.rb
@@ -4,18 +4,20 @@ require 'nokogiri'
 DEVICON_LANG_ALIAS = {
   'html' => 'html5',
   'shell' => 'bash',
+  'shell-session' => 'bash',
+  'sh' => 'bash',
   'tex' => 'latex',
   'nix' => 'nixos',
 }.freeze
 
-DEVICON_SVG_BASE = 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons'.freeze
+DEVICON_SVG_BASE = 'https://cdn.jsdelivr.net/gh/devicons/devicon@v2.17.0/icons'.freeze
 
 lambda { |content|
   html = Nokogiri::HTML(content)
 
   html.xpath('//p[span[@class="listing-name"]]').each do |pspan|
     highlight = pspan.next_element
-    highlight = highlight.next_element while highlight && !(highlight.name == 'div' && highlight['class']&.include?('highlight'))
+    highlight = highlight.next_element while highlight && !highlight.matches?('div.highlight')
     next unless highlight
 
     span = pspan.remove.xpath('span').remove
@@ -33,7 +35,7 @@ lambda { |content|
     icon['class'] = 'listing-icon'
     icon['src'] = "#{DEVICON_SVG_BASE}/#{devicon_name}/#{devicon_name}-original.svg"
     icon['alt'] = lang
-    icon['onerror'] = "this.style.display='none';this.nextSibling.dataset.noicon=''"
+    icon['onerror'] = "this.style.display='none'"
 
     if listing_name.children.empty?
       listing_name.add_child(icon)

--- a/_plugins/ordered/html_filters/99-listing_name_into_div.rb
+++ b/_plugins/ordered/html_filters/99-listing_name_into_div.rb
@@ -1,13 +1,45 @@
 require 'nokogiri'
 
-lambda { |content|
-  html = Nokogiri::HTML content
+# Rouge lang name → Devicon directory name (only where they differ)
+DEVICON_LANG_ALIAS = {
+  'html' => 'html5',
+  'shell' => 'bash',
+  'tex' => 'latex',
+  'nix' => 'nixos',
+}.freeze
 
-  pspans = html.xpath('//div[@class="highlight"]/preceding-sibling::p[span[@class="listing-name"]]')
-  divs = html.xpath('//p[span[@class="listing-name"]]/following-sibling::div[@class="highlight"]')
-  pspans.each_with_index do |pspan, idx|
+DEVICON_SVG_BASE = 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons'.freeze
+
+lambda { |content|
+  html = Nokogiri::HTML(content)
+
+  html.xpath('//p[span[@class="listing-name"]]').each do |pspan|
+    highlight = pspan.next_element
+    highlight = highlight.next_element while highlight && !(highlight.name == 'div' && highlight['class']&.include?('highlight'))
+    next unless highlight
+
     span = pspan.remove.xpath('span').remove
-    divs[idx].children.first.add_previous_sibling(span)
+    highlight.children.first.add_previous_sibling(span)
+
+    listing_name = highlight.at_css('span.listing-name')
+    next unless listing_name
+
+    code_el = highlight.at_css('code[data-lang]')
+    lang = code_el&.[]('data-lang')
+    next unless lang
+
+    devicon_name = DEVICON_LANG_ALIAS.fetch(lang, lang)
+    icon = Nokogiri::XML::Node.new('img', html)
+    icon['class'] = 'listing-icon'
+    icon['src'] = "#{DEVICON_SVG_BASE}/#{devicon_name}/#{devicon_name}-original.svg"
+    icon['alt'] = lang
+    icon['onerror'] = "this.style.display='none';this.nextSibling.dataset.noicon=''"
+
+    if listing_name.children.empty?
+      listing_name.add_child(icon)
+    else
+      listing_name.children.first.add_previous_sibling(icon)
+    end
   end
 
   html.xpath('//span[@class="listing-name" and string-length(text()) = 0]').remove

--- a/_plugins/ordered/html_filters/9901-lineno_into_highlight.rb
+++ b/_plugins/ordered/html_filters/9901-lineno_into_highlight.rb
@@ -1,0 +1,49 @@
+require 'nokogiri'
+
+lambda { |content|
+  html = Nokogiri::HTML(content)
+
+  html.css('div.lineno-source').each do |lineno_div|
+    # Find the next .highlight sibling
+    highlight = lineno_div.next_element
+    highlight = highlight.next_element while highlight && !highlight.matches?('div.highlight')
+    next unless highlight
+
+    highlight['class'] = "#{highlight['class']} has-lineno"
+
+    lineno_div.remove
+
+    # Create lineno pre with each number wrapped in a span
+    lineno_pre = Nokogiri::XML::Node.new('pre', html)
+    lineno_pre['class'] = 'lineno'
+
+    lineno_div.content.strip.split("\n").each do |num|
+      span = Nokogiri::XML::Node.new('span', html)
+      span['class'] = 'lineno-line'
+      span['data-line'] = num.strip
+      span.content = num.strip
+      lineno_pre.add_child(span)
+    end
+
+    code_pre = highlight.at_css('pre')
+    next unless code_pre
+
+    code_body = Nokogiri::XML::Node.new('div', html)
+    code_body['class'] = 'code-body'
+
+    # listing-name stays in highlight, icon stays inline inside listing-name
+    listing_name = highlight.at_css('span.listing-name')
+    if listing_name
+      listing_name.add_next_sibling(code_body)
+    elsif highlight.children.empty?
+      highlight.add_child(code_body)
+    else
+      highlight.children.first.add_previous_sibling(code_body)
+    end
+
+    code_body.add_child(lineno_pre)
+    code_body.add_child(code_pre)
+  end
+
+  html.xpath('/html/body/*').to_s
+}

--- a/_plugins/ordered/md_filters/09-lineno.rb
+++ b/_plugins/ordered/md_filters/09-lineno.rb
@@ -1,48 +1,43 @@
-lambda{|content|
-	newcontent = ""
+lambda { |content|
+  newcontent = ""
+  startwith = 0
+  codeacc = []
+  addlineno = false
 
-	startwith = 0
-	codeacc = []
-	addlineno = false
-	with_caption = false
+  content.each_line { |line|
+    unless addlineno
+      if (match = line.match(/^\s*<!--\s*linenumber(:(?<startline>\d+))?\s*-->/))
+        addlineno = true
+        startwith = (match['startline'] || 0).to_i
+      else
+        newcontent += line
+      end
 
-	content.each_line{|line|
-		if !addlineno
-			if match = line.match(/^\s*<!--\s*linenumber(:(?<startline>\d+))?\s*-->/)
-				addlineno = true
-				startwith = (match['startline'] or startwith).to_i
-			else
-				newcontent += line
-			end
+      next
+    end
 
-			next
-		end
+    if codeacc.empty?
+      if line.match(/^```/)
+        codeacc << line
+      else
+        newcontent += line
+      end
+    else
+      if line.match(/^```\s*$/)
+        codeacc << line
+        line_count = codeacc.length - 2
+        numbers = (1..line_count).map { |i| i + startwith }.join("\n")
+        newcontent += "<div class=\"lineno-source\">#{numbers}</div>\n\n"
+        newcontent += codeacc.join
 
-		if codeacc.length == 0
-			if match = line.match(/^```(?<cap>[^:]*:.*)?/)
-				codeacc << line
-				with_caption = !!match['cap']
-			else
-				newcontent += line
-			end
-		else
-			if line.match(/^```/)
-				codeacc << line
+        codeacc = []
+        addlineno = false
+        startwith = 0
+      else
+        codeacc << line
+      end
+    end
+  }
 
-				newcontent += "<div class=\"codeline#{with_caption ? " with_caption" : ""}\"><pre>" +
-					codeacc.take(codeacc.length - 2).map.with_index{|_, i|
-						i + 1 + startwith
-					}.join("\n") +
-					"</pre></div>\n\n" +
-					codeacc.join
-
-				codeacc = []
-				addlineno = false
-			else
-				codeacc << line
-			end
-		end
-	}
-
-	newcontent
+  newcontent
 }

--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -38,7 +38,9 @@ code {
     padding-left: 0;
 
     > .listing-icon {
-      width: calc(#{$codeline-width} - 5px);
+      width: calc(#{$codeline-width} - 0.3rem);
+      height: auto;
+      object-fit: contain;
       flex-shrink: 0;
       margin: 0 0.2rem 0 0.62rem;
     }
@@ -63,8 +65,8 @@ code {
     background: $listing-attach-background;
     color: $listing-attach-color;
     border-radius: unset;
-    padding-right: 5px;
-    padding-left: 8px;
+    padding-right: 0.3rem;
+    padding-left: 0.5rem;
     user-select: none;
 
     .lineno-line {

--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -1,74 +1,79 @@
 @use "variables" as *;
 @use "mixins" as *;
 
-$codeline-width: 2rem;
+$codeline-width: 2.5rem;
+$code-font-family: 'Droid Sans Mono', 'Bitstream Vera Sans Mono', 'Courier', monospace;
 
 code {
   margin: 0px 5px 0px 5px;
-  font-family: 'Droid Sans Mono', 'Bitstream Vera Sans Mono','Courier', monospace;
-}
-
-.codeline+.highlight {
-  margin-left: 0;
-}
-
-div.codeline {
-  font-size: $base-font-size;
-
-  float: left;
-  margin-left: -webkit-calc((100% - #{$widget-percent}) / 2 - #{$codeline-width});
-  margin-left:         calc((100% - #{$widget-percent}) / 2 - #{$codeline-width});
-  margin-top: .3rem;
-  background: $pre-background;
-  color: $listing-attach-color;
-  width: $codeline-width;
-
-  > pre {
-    text-align: right;
-    line-height: 1.54rem;
-    background: $listing-attach-background;
-    border-radius: unset;
-    padding-left: 5px;
-    font-family: inherit;
-
-    @include media-query($on-palm) {
-      padding-right: 5px;
-    }
-  }
-
-  @include media-query($on-palm) {
-    margin-left: -webkit-calc((100% - #{$widget-percent}) / 2 - #{$codeline-width} + 10px);
-    margin-left:         calc((100% - #{$widget-percent}) / 2 - #{$codeline-width} + 10px);
-    font-size: $base-font-size * 0.8;
-  }
+  font-family: $code-font-family;
 }
 
 .listing-name {
   font-size: $base-font-size;
   color: $listing-attach-color;
   background: $listing-attach-background;
-  padding: 0.3rem 0.3rem 0rem 0.3rem;
+  display: block;
+  padding: 0.1rem 0 0.1rem 0;
   line-height: 1.3;
+
+  .listing-icon {
+    display: inline;
+    height: .9em;
+    width: 1em;
+    margin: 0 0.3em 0 0.3rem;
+    vertical-align: middle;
+  }
+
 
   @include media-query($on-palm) {
     font-size: $base-font-size * 0.8;
   }
 }
 
-.with_caption {
-  font-size: $base-font-size;
-  margin-top: 5px !important;
+.highlight.has-lineno {
+  > .listing-name {
+    display: flex;
+    align-items: center;
+    padding-left: 0;
 
-  > pre {
-    padding-top: 1.9rem/* from top of caption to line number */;
-    padding-bottom: 8px/*pre padding-top*/;
-    @include media-query($on-palm) {
-      padding-top: 1.65rem;
+    > .listing-icon {
+      width: calc(#{$codeline-width} - 5px);
+      flex-shrink: 0;
+      margin: 0 0.2rem 0 0.62rem;
     }
   }
 
-  @include media-query($on-palm) {
-    font-size: $base-font-size * 0.8;
+  .code-body {
+    display: grid;
+    grid-template-columns: $codeline-width 1fr;
+
+    > .lineno {
+      grid-column: 1;
+    }
+
+    > pre:not(.lineno) {
+      grid-column: 2;
+    }
+  }
+
+  .lineno {
+    font-family: $code-font-family;
+    text-align: right;
+    background: $listing-attach-background;
+    color: $listing-attach-color;
+    border-radius: unset;
+    padding-right: 5px;
+    padding-left: 8px;
+    user-select: none;
+
+    .lineno-line {
+      display: block;
+    }
+
+    @include media-query($on-palm) {
+      font-size: $base-font-size * 0.8;
+    }
   }
 }
 
@@ -154,3 +159,4 @@ div.codeline {
     max-width: none;
   }
 }
+


### PR DESCRIPTION
## Summary
- Add Devicon SVG language icons to code listing names with automatic lang-to-icon mapping
- Restructure line number rendering into a separate HTML filter (`9901-lineno_into_highlight.rb`) using CSS grid layout
- Refactor syntax styles: extract font-family variable, widen line number gutter, add responsive grid for code bodies

## Test plan
- [ ] Verify code blocks with `<!-- linenumber -->` render line numbers in a grid alongside code
- [ ] Verify language icons appear next to listing names (try html, shell, nix, ruby, etc.)
- [ ] Verify icon fallback (`onerror`) hides broken icons gracefully
- [ ] Check responsive layout on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)