### PR TITLE
Fix Dependabot bundix workflow PAT secret

### DIFF
--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -36,4 +36,4 @@ jobs:
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
           message: "Update gemset.nix via bundix"
-          github_token: ${{ secrets.ACCESS_TOKEN || github.token }}
+          github_token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -36,4 +36,4 @@ jobs:
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
           message: "Update gemset.nix via bundix"
-          github_token: ${{ secrets.BOT_PAT || github.token }}
+          github_token: ${{ secrets.ACCESS_TOKEN || github.token }}


### PR DESCRIPTION
## Summary
- Dependabotトリガーのワークフローはrepo secretsにアクセスできず、Dependabot secretsのみ利用可能
- `secrets.BOT_PAT`(repo secret)が空になり `github.token` にフォールバック → pushによる `synchronize` イベントが発火せずCIが再実行されない問題を修正
- `secrets.ACCESS_TOKEN`(Dependabot secret)を使うように変更

## Test plan
- [ ] Dependabot PRで bundix workflow が PAT を使ってpushし、CIが再トリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)