### PR TITLE
Pass PAT to checkout in bundix workflow

### DIFF
--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.head_ref }}
+          token: ${{ secrets.ACCESS_TOKEN }}
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |

--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           ref: ${{ env.head_ref }}
           token: ${{ secrets.ACCESS_TOKEN }}
+          persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |


### PR DESCRIPTION
## Summary
- #149 で `ACCESS_TOKEN` を `EndBug/add-and-commit` に渡したが、`actions/checkout` が `persist-credentials: true`（デフォルト）で `GITHUB_TOKEN` をgit credentialに設定するため、pushは依然として `GITHUB_TOKEN` 経由だった
- `actions/checkout` の `token` にも `ACCESS_TOKEN` を渡すことで、pushがPAT経由になり `synchronize` イベントが発火してCIが再トリガーされるようにする

## Test plan
- [ ] Dependabot PRでbundixコミット後にCIが再実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)