### PR TITLE
Fix checkout auth: use github.token for clone, PAT for push only

### DIFF
--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.head_ref }}
-          token: ${{ secrets.ACCESS_TOKEN }}
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@main
         with:


### PR DESCRIPTION
## Summary
- #150 で `actions/checkout` に `ACCESS_TOKEN` を渡したが、このDependabot secretのPATが無効/期限切れ（最終更新 2024-09-01）でclone自体が失敗していた
- checkout は `github.token`（デフォルト）に戻し、`persist-credentials: false` で credential を保持しない
- push は `EndBug/add-and-commit` の `github_token` パラメータ経由で `ACCESS_TOKEN` を使う（このアクションは自前でremote URLにtokenを埋め込んでpushする）

## Test plan
- [ ] Dependabot PRで bundix workflow が成功し、gemset.nix 更新後にCIが再トリガーされることを確認
- [ ] `ACCESS_TOKEN` が期限切れの場合は push ステップのみが失敗し、エラーが明確に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)