### PR TITLE
Fix: pass PAT to checkout instead of persist-credentials: false

### DIFF
--- a/.github/workflows/hook-dependabot-rb.yml
+++ b/.github/workflows/hook-dependabot-rb.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.head_ref }}
-          persist-credentials: false
+          token: ${{ secrets.ACCESS_TOKEN }}
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |


### PR DESCRIPTION
## Summary
- `EndBug/add-and-commit@v9` はgit pushに `actions/checkout` が設定したcredentialを使う
- `persist-credentials: false` だとcredentialが消されてpush時に認証失敗
- `token: ACCESS_TOKEN` を checkout に渡し、`persist-credentials: true`（デフォルト）でPATがpush時にも使えるようにする

## Test plan
- [ ] マージ後、`@dependabot recreate` で PR #147 を再作成し、bundix push + CI再トリガーが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)